### PR TITLE
added loose config

### DIFF
--- a/finish/pom.xml
+++ b/finish/pom.xml
@@ -141,6 +141,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>

--- a/start/pom.xml
+++ b/start/pom.xml
@@ -141,6 +141,7 @@
                             <appsDirectory>apps</appsDirectory>
                             <stripVersion>true</stripVersion>
                             <installAppPackages>project</installAppPackages>
+                            <looseApplication>true</looseApplication>
                         </configuration>
                     </execution>
                     <execution>


### PR DESCRIPTION
Loose config is necessary to make applications work with `mvn compile`