### PR TITLE
Model changes

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/model/InventoryList.java
@@ -14,7 +14,9 @@ package io.openliberty.guides.inventory.model;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.eclipse.microprofile.openapi.annotations.media.Schema;
 
@@ -22,9 +24,9 @@ import org.eclipse.microprofile.openapi.annotations.media.Schema;
 public class InventoryList {
 
     @Schema(required = true)
-    private List<System> systems = new ArrayList<System>();
+    private Map<String, Properties> systems = new ConcurrentHashMap<String, Properties>();
 
-    public List<System> getSystems() {
+    public Map<String, Properties> getSystems() {
         return systems;
     }
 
@@ -36,40 +38,6 @@ public class InventoryList {
         Properties props = new Properties();
         props.setProperty("os.name", systemProps.getProperty("os.name"));
         props.setProperty("user.name", systemProps.getProperty("user.name"));
-
-        System host = new System(hostname, props);
-        if (!systems.contains(host)) {
-            systems.add(host);
-        }
-    }
-
-    @Schema(name="System", description="POJO that represents a single inventory entry.")
-    class System {
-
-        @Schema(required = true) 
-        private final String hostname;
-        @Schema(required = true) 
-        private final Properties properties;
-
-        public System(String hostname, Properties properties) {
-            this.hostname = hostname;
-            this.properties = properties;
-        }
-
-        public String getHostname() {
-            return hostname;
-        }
-
-        public Properties getProperties() {
-            return properties;
-        }
-
-        @Override
-        public boolean equals(Object host) {
-            if (host instanceof System) {
-                return hostname.equals(((System) host).getHostname());
-            }
-            return false;
-        }
+        systems.put(hostname, props);
     }
 }

--- a/finish/src/main/webapp/META-INF/openapi.yaml
+++ b/finish/src/main/webapp/META-INF/openapi.yaml
@@ -14,6 +14,18 @@ servers:
       description: Server HTTP port.
       default: "9080"
 paths:
+  /inventory/systems:
+    get:
+      summary: List inventory contents.
+      description: Returns the currently stored host:properties pairs in the inventory.
+      operationId: listContents
+      responses:
+        200:
+          description: host:properties pairs stored in the inventory.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/InventoryList'
   /inventory/systems/{hostname}:
     get:
       summary: Get JVM system properties for particular host
@@ -40,30 +52,18 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Properties'
-  /inventory/systems:
-    get:
-      summary: List inventory contents.
-      description: Returns the currently stored host:properties pairs in the inventory.
-      operationId: listContents
-      responses:
-        200:
-          description: host:properties pairs stored in the inventory.
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/InventoryList'
   /inventory/properties:
     get:
-      summary: Get JVM system properties.
-      description: Returns the JVM system properties for the host running this service.
       operationId: getProperties
       responses:
-        200:
-          description: JVM system properties of the host running this service.
+        default:
+          description: default response
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/Properties'
+                type: object
+                additionalProperties:
+                  type: string
 components:
   schemas:
     InventoryList:
@@ -72,9 +72,11 @@ components:
       type: object
       properties:
         systems:
-          type: array
-          items:
-            $ref: '#/components/schemas/System'
+          type: object
+          additionalProperties:
+            type: object
+            additionalProperties:
+              type: string
         total:
           type: integer
       description: POJO that represents the inventory contents.
@@ -82,16 +84,3 @@ components:
       type: object
       additionalProperties:
         type: string
-    System:
-      required:
-      - hostname
-      - properties
-      type: object
-      properties:
-        hostname:
-          type: string
-        properties:
-          type: object
-          additionalProperties:
-            type: string
-      description: POJO that represents a single inventory entry.

--- a/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
+++ b/finish/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
@@ -88,9 +88,7 @@ public class InventoryEndpointTest {
         int actual = obj.getInt("total");
         assertEquals("The inventory should have one entry for localhost", expected, actual);
 
-        boolean localhostExists = obj.getJsonArray("systems").getJsonObject(0)
-                                                             .get("hostname").toString()
-                                                             .contains("localhost");
+        boolean localhostExists = obj.getJsonObject("systems").containsKey("localhost");
         assertTrue("A host was registered, but it was not localhost", localhostExists);
 
         response.close();
@@ -104,9 +102,8 @@ public class InventoryEndpointTest {
         this.assertResponse(baseUrl, sysResponse);
 
         JsonObject jsonFromInventory = (JsonObject) invResponse.readEntity(JsonObject.class)
-                                                               .getJsonArray("systems")
-                                                               .getJsonObject(0)
-                                                               .get("properties");
+                                                               .getJsonObject("systems")
+                                                               .getJsonObject("localhost");
 
         JsonObject jsonFromSystem = sysResponse.readEntity(JsonObject.class);
 

--- a/start/src/main/webapp/META-INF/openapi.yaml
+++ b/start/src/main/webapp/META-INF/openapi.yaml
@@ -14,6 +14,18 @@
 #       description: Server HTTP port.
 #       default: "9080"
 # paths:
+#   /inventory/systems:
+#     get:
+#       summary: List inventory contents.
+#       description: Returns the currently stored host:properties pairs in the inventory.
+#       operationId: listContents
+#       responses:
+#         200:
+#           description: host:properties pairs stored in the inventory.
+#           content:
+#             application/json:
+#               schema:
+#                 $ref: '#/components/schemas/InventoryList'
 #   /inventory/systems/{hostname}:
 #     get:
 #       summary: Get JVM system properties for particular host
@@ -40,30 +52,18 @@
 #             application/json:
 #               schema:
 #                 $ref: '#/components/schemas/Properties'
-#   /inventory/systems:
-#     get:
-#       summary: List inventory contents.
-#       description: Returns the currently stored host:properties pairs in the inventory.
-#       operationId: listContents
-#       responses:
-#         200:
-#           description: host:properties pairs stored in the inventory.
-#           content:
-#             application/json:
-#               schema:
-#                 $ref: '#/components/schemas/InventoryList'
 #   /inventory/properties:
 #     get:
-#       summary: Get JVM system properties.
-#       description: Returns the JVM system properties for the host running this service.
 #       operationId: getProperties
 #       responses:
-#         200:
-#           description: JVM system properties of the host running this service.
+#         default:
+#           description: default response
 #           content:
 #             application/json:
 #               schema:
-#                 $ref: '#/components/schemas/Properties'
+#                 type: object
+#                 additionalProperties:
+#                   type: string
 # components:
 #   schemas:
 #     InventoryList:
@@ -72,9 +72,11 @@
 #       type: object
 #       properties:
 #         systems:
-#           type: array
-#           items:
-#             $ref: '#/components/schemas/System'
+#           type: object
+#           additionalProperties:
+#             type: object
+#             additionalProperties:
+#               type: string
 #         total:
 #           type: integer
 #       description: POJO that represents the inventory contents.
@@ -82,16 +84,3 @@
 #       type: object
 #       additionalProperties:
 #         type: string
-#     System:
-#       required:
-#       - hostname
-#       - properties
-#       type: object
-#       properties:
-#         hostname:
-#           type: string
-#         properties:
-#           type: object
-#           additionalProperties:
-#             type: string
-#       description: POJO that represents a single inventory entry.

--- a/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
+++ b/start/src/test/java/it/io/openliberty/guides/inventory/InventoryEndpointTest.java
@@ -88,9 +88,7 @@ public class InventoryEndpointTest {
         int actual = obj.getInt("total");
         assertEquals("The inventory should have one entry for localhost", expected, actual);
 
-        boolean localhostExists = obj.getJsonArray("systems").getJsonObject(0)
-                                                             .get("hostname").toString()
-                                                             .contains("localhost");
+        boolean localhostExists = obj.getJsonObject("systems").containsKey("localhost");
         assertTrue("A host was registered, but it was not localhost", localhostExists);
 
         response.close();
@@ -104,9 +102,8 @@ public class InventoryEndpointTest {
         this.assertResponse(baseUrl, sysResponse);
 
         JsonObject jsonFromInventory = (JsonObject) invResponse.readEntity(JsonObject.class)
-                                                               .getJsonArray("systems")
-                                                               .getJsonObject(0)
-                                                               .get("properties");
+                                                               .getJsonObject("systems")
+                                                               .getJsonObject("localhost");
 
         JsonObject jsonFromSystem = sysResponse.readEntity(JsonObject.class);
 


### PR DESCRIPTION
I made the data model and concurrency changes.

**Documentation generated before changes**

```
openapi: 3.0.0
info:
  title: Inventory App
  description: App for storing JVM system properties of various hosts.
  license:
    name: Eclipse Public License - v 1.0
    url: https://www.eclipse.org/legal/epl-v10.html
  version: "1.0"
servers:
- url: http://localhost:{port}
  description: Simple Open Liberty.
  variables:
    port:
      description: Server HTTP port.
      default: "9080"
paths:
  /inventory/systems/{hostname}:
    get:
      summary: Get JVM system properties for particular host
      description: Retrieves and returns the JVM system properties from the system
        service running on the particular host.
      operationId: getPropertiesForHost
      parameters:
      - name: hostname
        in: path
        description: The host for whom to retrieve the JVM system properties for.
        required: true
        explode: false
        schema:
          type: string
        example: foo
      responses:
        404:
          description: Invalid hostname or the system service may not be running on
            the particular host.
          content:
            text/plain: {}
        200:
          description: JVM system properties of a particular host.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Properties'
  /inventory/systems:
    get:
      summary: List inventory contents.
      description: Returns the currently stored host:properties pairs in the inventory.
      operationId: listContents
      responses:
        200:
          description: host:properties pairs stored in the inventory.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/InventoryList'
  /inventory/properties:
    get:
      summary: Get JVM system properties.
      description: Returns the JVM system properties for the host running this service.
      operationId: getProperties
      responses:
        200:
          description: JVM system properties of the host running this service.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Properties'
components:
  schemas:
    InventoryList:
      required:
      - systems
      type: object
      properties:
        systems:
          type: array
          items:
            $ref: '#/components/schemas/System'
        total:
          type: integer
      description: POJO that represents the inventory contents.
    Properties:
      type: object
      additionalProperties:
        type: string
    System:
      required:
      - hostname
      - properties
      type: object
      properties:
        hostname:
          type: string
        properties:
          type: object
          additionalProperties:
            type: string
      description: POJO that represents a single inventory entry.
```

**Documentation generated after changes**
```
openapi: 3.0.0
info:
  title: Inventory App
  description: App for storing JVM system properties of various hosts.
  license:
    name: Eclipse Public License - v 1.0
    url: https://www.eclipse.org/legal/epl-v10.html
  version: "1.0"
servers:
- url: http://localhost:{port}
  description: Simple Open Liberty.
  variables:
    port:
      description: Server HTTP port.
      default: "9080"
paths:
  /inventory/systems:
    get:
      summary: List inventory contents.
      description: Returns the currently stored host:properties pairs in the inventory.
      operationId: listContents
      responses:
        200:
          description: host:properties pairs stored in the inventory.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/InventoryList'
  /inventory/systems/{hostname}:
    get:
      summary: Get JVM system properties for particular host
      description: Retrieves and returns the JVM system properties from the system
        service running on the particular host.
      operationId: getPropertiesForHost
      parameters:
      - name: hostname
        in: path
        description: The host for whom to retrieve the JVM system properties for.
        required: true
        schema:
          type: string
        example: foo
      responses:
        404:
          description: Invalid hostname or the system service may not be running on
            the particular host.
          content:
            text/plain: {}
        200:
          description: JVM system properties of a particular host.
          content:
            application/json:
              schema:
                $ref: '#/components/schemas/Properties'
  /inventory/properties:
    get:
      operationId: getProperties
      responses:
        default:
          description: default response
          content:
            application/json:
              schema:
                type: object
                additionalProperties:
                  type: string
components:
  schemas:
    InventoryList:
      required:
      - systems
      type: object
      properties:
        systems:
          type: object
          additionalProperties:
            type: object
            additionalProperties:
              type: string
        total:
          type: integer
      description: POJO that represents the inventory contents.
    Properties:
      type: object
      additionalProperties:
        type: string
```