### PR TITLE
Removed @Dependent annotation from MP Rest Client

### DIFF
--- a/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/finish/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")

--- a/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
+++ b/start/src/main/java/io/openliberty/guides/inventory/client/SystemClient.java
@@ -22,7 +22,7 @@ import javax.ws.rs.core.MediaType;
 import org.eclipse.microprofile.rest.client.annotation.RegisterProvider;
 import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
 
-@Dependent
+
 @RegisterRestClient
 @RegisterProvider(UnknownUrlExceptionMapper.class)
 @Path("/properties")


### PR DESCRIPTION
With the MP Rest Client 1.1 update, it is no longer necessary to add the @dependent annotation (or any scope annotation) to the Rest Client interface for CDI to recognize and process it because @RegisterRestClient is now a bean-defining annotation.